### PR TITLE
Fix ESLint prefer-const violation in SimulationPage

### DIFF
--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -235,7 +235,7 @@ export default function SimulationPage() {
       const deviceEvents = scenario
         .filter((e) => e.deviceId === d.id && e.hour <= startH)
         .sort((a, b) => a.hour - b.hour);
-      let state = { ...d };
+      const state = { ...d };
       deviceEvents.forEach((e) => {
         if (e.switchedOn !== undefined) state.switchedOn = e.switchedOn;
         if (e.level !== undefined) state.level = e.level;


### PR DESCRIPTION
## Summary
- Fix ESLint `prefer-const` lint error in `SimulationPage.tsx` line 238
- Changed `let state` to `const state` since the variable is never reassigned (only its properties are mutated)
- Fixes CI pipeline failure

## Test plan
- [ ] CI pipeline passes (lint + build)
- [ ] Simulation page still works correctly (start, pause, resume, stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)