### PR TITLE
Real-time UI updates via WebSocket

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-next</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>

--- a/backend/src/main/java/at/jku/se/resource/DeviceResource.java
+++ b/backend/src/main/java/at/jku/se/resource/DeviceResource.java
@@ -8,6 +8,7 @@ import at.jku.se.iot.IoTIntegrationService;
 import at.jku.se.mapper.DeviceMapper;
 import at.jku.se.repository.ActivityLogRepository;
 import at.jku.se.repository.DeviceRepository;
+import at.jku.se.websocket.DeviceEventBroadcaster;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -42,6 +43,9 @@ public class DeviceResource {
 
     @Inject
     IoTIntegrationService iotService;
+
+    @Inject
+    DeviceEventBroadcaster deviceEventBroadcaster;
 
     /**
      * Returns a single device including its current state (FR-07).
@@ -146,6 +150,8 @@ public class DeviceResource {
         activityLogRepo.persist(log);
 
         iotService.pushStateToHardware(device);
+
+        deviceEventBroadcaster.broadcastDeviceUpdate(DeviceMapper.toResponse(device));
 
         return Response.ok(DeviceMapper.toResponse(device)).build();
     }

--- a/backend/src/main/java/at/jku/se/websocket/DeviceEventBroadcaster.java
+++ b/backend/src/main/java/at/jku/se/websocket/DeviceEventBroadcaster.java
@@ -1,0 +1,46 @@
+package at.jku.se.websocket;
+
+import at.jku.se.dto.response.DeviceResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.quarkus.websockets.next.OpenConnections;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Broadcasts device state changes to all connected WebSocket clients (FR-07).
+ */
+@ApplicationScoped
+public class DeviceEventBroadcaster {
+
+    private static final Logger LOG = Logger.getLogger(DeviceEventBroadcaster.class.getName());
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Inject
+    OpenConnections connections;
+
+    /**
+     * Sends a device state update to all connected WebSocket clients.
+     */
+    public void broadcastDeviceUpdate(DeviceResponse device) {
+        try {
+            String json = MAPPER.writeValueAsString(new DeviceStateMessage("DEVICE_STATE_CHANGED", device));
+            connections.forEach(c -> c.sendText(json).subscribe().asCompletionStage());
+        } catch (JsonProcessingException e) {
+            if (LOG.isLoggable(Level.WARNING)) {
+                LOG.log(Level.WARNING, "Failed to serialize device update", e);
+            }
+        }
+    }
+
+    /**
+     * Message wrapper sent to WebSocket clients.
+     */
+    public record DeviceStateMessage(String type, DeviceResponse device) {
+    }
+}

--- a/backend/src/main/java/at/jku/se/websocket/DeviceStateSocket.java
+++ b/backend/src/main/java/at/jku/se/websocket/DeviceStateSocket.java
@@ -1,0 +1,38 @@
+package at.jku.se.websocket;
+
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+import jakarta.inject.Inject;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * WebSocket endpoint for real-time device state updates (FR-07).
+ * Clients connect to /ws/devices and receive JSON messages
+ * whenever a device state changes.
+ */
+@WebSocket(path = "/ws/devices")
+public class DeviceStateSocket {
+
+    private static final Logger LOG = Logger.getLogger(DeviceStateSocket.class.getName());
+
+    @Inject
+    WebSocketConnection connection;
+
+    @OnOpen
+    public void onOpen() {
+        if (LOG.isLoggable(Level.INFO)) {
+            LOG.info("WebSocket client connected: " + connection.id());
+        }
+    }
+
+    @OnClose
+    public void onClose() {
+        if (LOG.isLoggable(Level.INFO)) {
+            LOG.info("WebSocket client disconnected: " + connection.id());
+        }
+    }
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,4 +15,15 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
+
+    # WebSocket-Verbindungen an das Backend weiterleiten (FR-07)
+    location /ws/ {
+        proxy_pass http://backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 3600s;
+    }
 }

--- a/frontend/src/hooks/useDeviceWebSocket.ts
+++ b/frontend/src/hooks/useDeviceWebSocket.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from "react";
+import type { Device } from "@/types/types";
+
+interface DeviceStateMessage {
+  type: string;
+  device: Device;
+}
+
+/**
+ * Hook that connects to the backend WebSocket and calls onDeviceUpdate
+ * whenever a device state changes in real-time (FR-07).
+ */
+export function useDeviceWebSocket(onDeviceUpdate: (device: Device) => void) {
+  const callbackRef = useRef(onDeviceUpdate);
+
+  useEffect(() => {
+    callbackRef.current = onDeviceUpdate;
+  }, [onDeviceUpdate]);
+
+  useEffect(() => {
+    let ws: WebSocket | null = null;
+    let closed = false;
+
+    function connect() {
+      if (closed) return;
+      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const wsUrl = `${protocol}//${window.location.host}/ws/devices`;
+
+      ws = new WebSocket(wsUrl);
+
+      ws.onmessage = (event) => {
+        try {
+          const message: DeviceStateMessage = JSON.parse(event.data);
+          if (message.type === "DEVICE_STATE_CHANGED" && message.device) {
+            callbackRef.current(message.device);
+          }
+        } catch {
+          // ignore malformed messages
+        }
+      };
+
+      ws.onclose = () => {
+        if (!closed) {
+          setTimeout(connect, 3000);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      closed = true;
+      ws?.close();
+    };
+  }, []);
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/services/api";
+import { useDeviceWebSocket } from "@/hooks/useDeviceWebSocket";
 import { Badge } from "@/components/ui/badge";
 import { DoorOpen, Lightbulb, Zap, ShieldCheck, Clock, Activity, Wifi, WifiOff } from "lucide-react";
 
@@ -62,6 +63,12 @@ export default function DashboardPage() {
   useEffect(() => {
     loadDashboard();
   }, []);
+
+  const handleWebSocketUpdate = useCallback((updatedDevice: Device) => {
+    setDevices((prev) => prev.map((d) => (d.id === updatedDevice.id ? updatedDevice : d)));
+  }, []);
+
+  useDeviceWebSocket(handleWebSocketUpdate);
 
   async function loadDashboard() {
     try {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,21 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/services/api";
 import { useDeviceWebSocket } from "@/hooks/useDeviceWebSocket";
+import type { Device } from "@/types/types";
 import { Badge } from "@/components/ui/badge";
 import { DoorOpen, Lightbulb, Zap, ShieldCheck, Clock, Activity, Wifi, WifiOff } from "lucide-react";
 
 interface Room {
   id: number;
   name: string;
-}
-
-interface Device {
-  id: number;
-  name: string;
-  type: string;
-  switchedOn?: boolean;
-  level?: number;
-  roomName?: string;
 }
 
 interface Rule {

--- a/frontend/src/pages/DevicesPage.tsx
+++ b/frontend/src/pages/DevicesPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { api } from "@/services/api";
 import { useAuth } from "@/contexts/AuthContext";
+import { useDeviceWebSocket } from "@/hooks/useDeviceWebSocket";
 import type { Room, Device, DeviceType } from "@/types/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -84,6 +85,12 @@ export default function DevicesPage() {
   useEffect(() => {
     fetchData();
   }, [user]);
+
+  const handleWebSocketUpdate = useCallback((updatedDevice: Device) => {
+    setAllDevices((prev) => prev.map((d) => (d.id === updatedDevice.id ? updatedDevice : d)));
+  }, []);
+
+  useDeviceWebSocket(handleWebSocketUpdate);
 
   const updateDeviceState = async (device: Device, switchedOn?: boolean, level?: number) => {
     try {


### PR DESCRIPTION
## Summary
- Add WebSocket endpoint `/ws/devices` for real-time device state updates
- Broadcast device state changes to all connected clients via `DeviceEventBroadcaster`
- Add `useDeviceWebSocket` React hook with automatic reconnection
- Integrate real-time updates into DevicesPage and DashboardPage
- Configure nginx WebSocket proxy for production

## Test plan
- [x] TypeScript compiles without errors
- [x] PMD passes
- [x] Frontend lint passes (0 errors)
- [ ] CI pipeline passes