### PR TITLE
#82 [0.2h] fixing dead javadoc links in readme and handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ steht im Benutzerhandbuch:
 
 ## Generierte API-Dokumentation
 
-- [JavaDoc (HTML)](docs/javadoc/index.html)
+JavaDoc wird bei Bedarf lokal generiert (nicht ins Repo eingecheckt):
+
+```bash
+cd backend
+mvn javadoc:javadoc
+```
+
+Output: `backend/target/site/apidocs/index.html` im Browser öffnen.
 
 
 ## Dokumentation der Anforderungen

--- a/docs/user-handbook.md
+++ b/docs/user-handbook.md
@@ -105,5 +105,5 @@ Im Entwicklungsmodus kann die Datenbank bei Neustart neu erstellt werden.
 
 ### Wo finde ich API-Details?
 
-In der generierten Javadoc-Dokumentation unter docs/javadoc/index.html.
+Die JavaDoc wird lokal mit `mvn javadoc:javadoc` (im `backend/`-Verzeichnis) generiert und liegt anschließend unter `backend/target/site/apidocs/index.html`.
 


### PR DESCRIPTION
Closes #82