### PR TITLE
chore: add Docker launcher scripts and disable startup test data

### DIFF
--- a/backend/src/main/java/at/jku/se/StartupDataLoader.java
+++ b/backend/src/main/java/at/jku/se/StartupDataLoader.java
@@ -22,19 +22,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.jboss.logging.Logger;
 
-/**
- * Loads realistic sample data on every application startup.
- * Only runs when the database is empty (no users exist yet).
- * Because {@code quarkus.hibernate-orm.database.generation=drop-and-create} is active,
- * the schema is always fresh and this loader always populates it.
- *
- * <p>Test credentials:
- * <ul>
- *   <li>Owner: alice@example.com / password123</li>
- *   <li>Member: bob@example.com / password123</li>
- * </ul>
- */
-@ApplicationScoped
+// StartupDataLoader is disabled — no test data will be inserted on startup.
+// To re-enable, uncomment @ApplicationScoped and restore @Observes below.
+
+// @ApplicationScoped
 public class StartupDataLoader {
 
     private static final Logger LOG = Logger.getLogger(StartupDataLoader.class);
@@ -45,7 +36,7 @@ public class StartupDataLoader {
         }
 
     @Transactional
-    void onStart(@Observes StartupEvent ev) {
+    void onStart(/* @Observes */ StartupEvent ev) {
         if (User.count() > 0) {
             LOG.info("Database already has data — skipping seed.");
             return;

--- a/start-app.bat
+++ b/start-app.bat
@@ -1,0 +1,60 @@
+@echo off
+title SmartHome – Docker Launcher
+
+echo ============================================
+echo  SmartHome – Starting via Docker Compose
+echo ============================================
+echo.
+
+:: Check if Docker is running
+docker info >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [ERROR] Docker is not running or not installed.
+    echo         Please start Docker Desktop and try again.
+    echo.
+    pause
+    exit /b 1
+)
+
+echo [INFO] Building and starting all services (detached) ...
+echo        This may take a few minutes on the first run.
+echo.
+
+docker compose up --build -d
+
+if %errorlevel% neq 0 (
+    echo.
+    echo [ERROR] docker compose exited with an error.
+    pause
+    exit /b %errorlevel%
+)
+
+:: Wait until the frontend is reachable, then open the browser
+echo [INFO] Waiting for frontend to become ready on http://localhost:3000 ...
+set RETRIES=30
+:wait_loop
+curl -s -o nul -w "%%{http_code}" http://localhost:3000 | findstr /r "^[23]" >nul 2>&1
+if %errorlevel% equ 0 (
+    echo [INFO] Frontend is ready – opening browser ...
+    start "" "http://localhost:3000"
+    goto show_logs
+)
+set /a RETRIES-=1
+if %RETRIES% leq 0 (
+    echo [WARN] Frontend did not respond in time – opening browser anyway ...
+    start "" "http://localhost:3000"
+    goto show_logs
+)
+timeout /t 2 /nobreak >nul
+goto wait_loop
+
+:show_logs
+echo.
+echo [INFO] Streaming logs (Ctrl+C to stop) ...
+echo.
+docker compose logs -f
+
+echo.
+echo [INFO] All services are still running in the background.
+echo        To stop them, run:  docker compose down
+pause

--- a/start-app.sh
+++ b/start-app.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "============================================"
+echo " SmartHome – Starting via Docker Compose"
+echo "============================================"
+echo
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "[ERROR] Docker is not running or not installed."
+    echo "        Please start Docker Desktop and try again."
+    exit 1
+fi
+
+echo "[INFO] Building and starting all services (detached) ..."
+echo "       This may take a few minutes on the first run."
+echo
+
+docker compose up --build -d
+
+# Wait until the frontend is reachable, then open the browser
+echo "[INFO] Waiting for frontend to become ready on http://localhost:3000 ..."
+RETRIES=30
+until curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 | grep -qE '^[23]'; do
+    RETRIES=$((RETRIES - 1))
+    if [ "$RETRIES" -le 0 ]; then
+        echo "[WARN] Frontend did not respond in time – opening browser anyway ..."
+        break
+    fi
+    sleep 2
+done
+
+echo "[INFO] Frontend is ready – opening browser ..."
+# macOS uses 'open', Linux uses 'xdg-open'
+if command -v open > /dev/null 2>&1; then
+    open "http://localhost:3000"
+elif command -v xdg-open > /dev/null 2>&1; then
+    xdg-open "http://localhost:3000"
+else
+    echo "[WARN] Could not detect a browser opener. Visit http://localhost:3000 manually."
+fi
+
+echo
+echo "[INFO] Streaming logs (Ctrl+C to stop) ..."
+echo
+docker compose logs -f
+
+echo
+echo "[INFO] All services are still running in the background."
+echo "       To stop them, run:  docker compose down"


### PR DESCRIPTION
- Add start-app.bat (Windows) and start-app.sh (macOS/Linux) to build and start all services via docker compose, poll until the frontend is reachable on localhost:3000, then open the browser automatically and stream container logs
- Disable StartupDataLoader: remove @ApplicationScoped and @Observes so no seed data is inserted on startup